### PR TITLE
Added logging to external neo4j startup config.  Fixing bootRun system properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ bootRun{
     jvmArgs '-Dspring.profiles.active=embedded'
   }
   addResources = true
-  systemProperties = System.properties
+  systemProperties System.properties
 }
 
 //We enable publishing of vantage as a generic jar so that it can be augmented by end-users if desired prior to being run

--- a/src/main/java/com/yodle/vantage/config/ExternalNeo4jConfig.java
+++ b/src/main/java/com/yodle/vantage/config/ExternalNeo4jConfig.java
@@ -17,6 +17,8 @@ package com.yodle.vantage.config;
 
 import javax.sql.DataSource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,8 +33,11 @@ public class ExternalNeo4jConfig {
     @Value("${neo4j.user:neo4j}") String neo4jUsername;
     @Value("${neo4j.user:password}") String neo4jPassword;
 
+    private static final Logger l = LoggerFactory.getLogger(ExternalNeo4jConfig.class);
+
     @Bean
     public DataSource neo4jDataSource() {
+        l.info("Connecting to neo4j server at {}:{}", neo4jServer, neo4jPort);
         DriverManagerDataSource ds = new DriverManagerDataSource(
                 String.format(
                         "jdbc:neo4j://%s:%d",


### PR DESCRIPTION
the `systemProperties = System.properties` was added so that you could specify java opts from the command line (e.g. `./gradlew bootRun -Dneo4j.server=neo4jserver:7474`).  However it turns out that 
`systemProperties = System.properties` causes the system properties bootRun uses to be overwritten (which includes wiping out the jvmArgs setting `spring.profiles.active=embedded`).  This broke `-Pembedded`.  `systemProperties System.properties` _adds_ the system properties to bootRun's properties., which means that both `-Pembedded` and `-Dproperty=value` args both work.
